### PR TITLE
Fix Bedrock example for UTCP 1.0.1 compatibility, and other few bugs and inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# UTCP Examples
+
+This repository contains practical examples demonstrating how to use the Universal Tool Calling Protocol (UTCP) in different programming languages and scenarios.
+
+## Structure
+
+- **`python/`** - Examples for Python applications
+- **`typescript/`** - Examples for TypeScript/Node.js applications
+
+## Getting Started
+
+1. Navigate to any example directory and follow the setup instructions in that example's README.
+
+2. Configure your environment variables (most examples include an `example.env` file as a template).
+
+## Key Concepts
+
+- **Tools**: Individual functions or APIs that can be called
+- **Call Templates**: Configuration for how to connect to tool providers
+- **Manuals**: Collections of tools from a single provider
+- **Client**: The main interface for discovering and calling tools
+
+## Documentation
+
+For detailed documentation and API reference, visit:
+- [Python UTCP repository](https://github.com/universal-tool-calling-protocol/python-utcp)
+- [TypeScript UTCP repository](https://github.com/universal-tool-calling-protocol/typescript-utcp)

--- a/python/bedrock_llm_tool_calling_example/bedrock_utcp_example.py
+++ b/python/bedrock_llm_tool_calling_example/bedrock_utcp_example.py
@@ -21,9 +21,9 @@ import traceback
 import boto3
 from dotenv import load_dotenv
 
-from utcp.client.utcp_client import UtcpClient
-from utcp.client.utcp_client_config import UtcpClientConfig, UtcpDotEnv
-from utcp.shared.tool import Tool
+from utcp.utcp_client import UtcpClient
+from utcp.data.utcp_client_config import UtcpClientConfigSerializer
+from utcp.data.tool import Tool
 
 # Global debug flag
 DEBUG = False
@@ -34,14 +34,9 @@ modelId = 'anthropic.claude-3-sonnet-20240229-v1:0'
 
 async def initialize_utcp_client() -> UtcpClient:
     """Initialize the UTCP client with configuration."""
-    config = UtcpClientConfig(
-        providers_file_path=str(Path(__file__).parent / "providers.json"),
-        load_variables_from=[
-            UtcpDotEnv(env_file_path=str(Path(__file__).parent / ".env"))
-        ]
-    )
-    
-    client = await UtcpClient.create(config)
+    # Load configuration from the providers.json file
+    config_path = str(Path(__file__).parent / "providers.json")
+    client = await UtcpClient.create(config=config_path)
     return client
 
 

--- a/python/bedrock_llm_tool_calling_example/bedrock_utcp_example.py
+++ b/python/bedrock_llm_tool_calling_example/bedrock_utcp_example.py
@@ -65,11 +65,11 @@ def format_tools_for_bedrock(tools: List[Tool]) -> Tuple[List[Dict[str, Any]], D
             "required": []
         }
         
-        # Add parameters to the input schema
-        if "parameters" in schema and "properties" in schema["parameters"]:
-            input_schema_json["properties"] = schema["parameters"]["properties"]
-            if "required" in schema["parameters"]:
-                input_schema_json["required"] = schema["parameters"]["required"]
+        # Add inputs to the input schema
+        if "inputs" in schema and "properties" in schema["inputs"]:
+            input_schema_json["properties"] = schema["inputs"]["properties"]
+            if "required" in schema["inputs"]:
+                input_schema_json["required"] = schema["inputs"]["required"]
         
         # Replace periods in tool name with underscores
         original_name = tool.name

--- a/python/bedrock_llm_tool_calling_example/providers.json
+++ b/python/bedrock_llm_tool_calling_example/providers.json
@@ -1,14 +1,22 @@
-[
-    {
-        "name": "openlibrary",
-        "provider_type": "http",
-        "http_method": "GET",
-        "url": "https://openlibrary.org/static/openapi.json",
-        "content_type": "application/json"
-    },
-    {
-        "name": "newsapi",
-        "provider_type": "text",
-        "file_path": "./newsapi_manual.json"
-    }
-]
+{
+    "load_variables_from": [
+        {
+            "variable_loader_type": "dotenv",
+            "env_file_path": ".env"
+        }
+    ],
+    "manual_call_templates": [
+        {
+            "name": "openlibrary",
+            "call_template_type": "http",
+            "http_method": "GET",
+            "url": "https://openlibrary.org/static/openapi.json",
+            "content_type": "application/json"
+        },
+        {
+            "name": "newsapi",
+            "call_template_type": "text",
+            "file_path": "./newsapi_manual.json"
+        }
+    ]
+}

--- a/python/openai_llm_tool_calling_example/openai_utcp_example.py
+++ b/python/openai_llm_tool_calling_example/openai_utcp_example.py
@@ -54,7 +54,7 @@ async def initialize_utcp_client() -> UtcpClient:
                 {
                     "name": "newsapi",
                     "call_template_type": "text",
-                    "file_path": ".\\newsapi_manual.json"
+                    "file_path": "./newsapi_manual.json"
                 }
             ],
             "post_processing": [
@@ -68,10 +68,7 @@ async def initialize_utcp_client() -> UtcpClient:
     )
     
     # Create and return the UTCP client
-    client = await UtcpClient.create(
-        root_dir="C:\\Users\\razva\\Documents\\Startup\\utcp\\utcp-examples\\python\\openai_llm_tool_calling_example",
-        config=config
-    )
+    client = await UtcpClient.create(config=config)
     return client
 
 def format_tools_for_prompt(tools: List[Tool]) -> str:


### PR DESCRIPTION
- Update imports from utcp.client.* to utcp.* paths
- Convert providers.json from array to full config object format
- Change provider_type to call_template_type in configuration
- Simplify client initialization to use direct file loading
- Maintain file-based configuration approach
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updates the Bedrock LLM tool-calling example for UTCP 1.0.1 compatibility, restoring a working run path. Uses the new config format and simpler client initialization while keeping the file-based setup.

- **Migration**
  - Switch imports to utcp.* modules.
  - Convert providers.json to the new config shape with load_variables_from and manual_call_templates.
  - Rename provider_type to call_template_type.
  - Initialize the client with the config file path: UtcpClient.create(config="path/to/providers.json").

<!-- End of auto-generated description by cubic. -->

