### PR TITLE
Add cli example

### DIFF
--- a/python/communication_protocols/cli/cli_manual.json
+++ b/python/communication_protocols/cli/cli_manual.json
@@ -1,0 +1,35 @@
+{
+  "manual_version": "1.0.0",
+  "utcp_version": "1.0.1",
+  "tools": [
+    {
+      "name": "my_cli_tool",
+      "description": "string",
+      "inputs": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "text"
+        ]
+      },
+      "outputs": {
+        "type": "string"
+      },
+      "tags": [
+        "echo"
+      ],
+      "tool_call_template": {
+        "call_template_type": "cli",
+        "command_name": "./script.sh",
+        "env_vars": {
+          "API_KEY": "$API_KEY"
+        },
+        "working_dir": "."
+      }
+    }
+  ]
+}

--- a/python/communication_protocols/cli/client.py
+++ b/python/communication_protocols/cli/client.py
@@ -1,0 +1,47 @@
+import asyncio
+from os import getcwd
+from utcp.utcp_client import UtcpClient
+from utcp.data.utcp_client_config import UtcpClientConfigSerializer
+from utcp.data.variable_loader import VariableLoaderSerializer
+
+async def main():
+    client: UtcpClient = await UtcpClient.create(
+        root_dir=getcwd(),
+        config=UtcpClientConfigSerializer().validate_dict(
+            {
+                "load_variables_from": [
+                    VariableLoaderSerializer().validate_dict({
+                        "variable_loader_type": "dotenv",
+                        "env_file_path": "example.env"
+                    })
+                ],
+                "manual_call_templates": [
+                    {
+                        "name": "my_cli",
+                        "call_template_type": "text",
+                        "file_path": "cli_manual.json"
+                    }
+                ]
+            }
+        )
+    )
+
+    # List all available tools
+    print("Registered tools:")
+    tools = await client.search_tools("")
+    for tool in tools:
+        print(f" - {tool.name}")
+
+    # Call one of the tools
+    if tools:
+        tool_to_call = tools[0].name
+        args = {"text": "TestText"}
+
+        result = await client.call_tool(tool_to_call, args)
+        print(f"\nTool call result for '{tool_to_call}':")
+        print(result)
+    else:
+        print("No tools found.")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/communication_protocols/cli/example.env
+++ b/python/communication_protocols/cli/example.env
@@ -1,0 +1,1 @@
+my__cli_API_KEY=TEST

--- a/python/communication_protocols/cli/requirements.txt
+++ b/python/communication_protocols/cli/requirements.txt
@@ -1,0 +1,2 @@
+utcp
+utcp-cli

--- a/python/communication_protocols/cli/script.sh
+++ b/python/communication_protocols/cli/script.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Check API_KEY
+if [[ -z "$API_KEY" ]]; then
+    echo "API_KEY is not set." >&2
+    exit 1
+fi
+
+if [[ "$API_KEY" != "TEST" ]]; then
+    echo "API_KEY value is not TEST." >&2
+    exit 1
+fi
+
+# Parse --text argument
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --text)
+            TEXT="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$TEXT" ]]; then
+    echo "No --text argument provided." >&2
+    exit 1
+fi
+
+echo "$TEXT"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a minimal UTCP CLI example that defines a CLI tool and a Python client that loads env vars from .env and calls the tool. This helps developers test and learn CLI-based tool calls.

- **New Features**
  - cli_manual.json: registers a CLI tool that runs ./script.sh and maps API_KEY from env.
  - script.sh: checks API_KEY=TEST, parses --text, and echoes it.
  - client.py: creates UtcpClient, loads example.env via dotenv, lists tools, and calls the first tool with {"text": "TestText"}.
  - example.env: sample env var for the tool. 
  - requirements.txt: adds utcp and utcp-cli.

<!-- End of auto-generated description by cubic. -->

