### PR TITLE
bug fix plus add README in python Bedrock example

### DIFF
--- a/python/bedrock_llm_tool_calling_example/README.md
+++ b/python/bedrock_llm_tool_calling_example/README.md
@@ -1,0 +1,89 @@
+# Amazon Bedrock + UTCP Tool Calling Example
+
+This example demonstrates how to integrate the Universal Tool Calling Protocol (UTCP) with Amazon Bedrock to enable dynamic tool discovery and execution. The system searches for relevant tools based on user queries, instructs Bedrock to make tool calls, and executes those tools using UTCP call templates that provide direct access to existing APIs as LLM tools.
+
+## What This Example Does
+
+1. **Tool Discovery**: Searches available UTCP tools based on user input
+2. **LLM Integration**: Uses Amazon Bedrock to determine which tools to call
+3. **Tool Execution**: Executes the selected tools via UTCP call templates and returns results
+4. **Response Generation**: Provides final responses incorporating tool results
+
+**Note**: This is a client-only example - no server is involved. The call templates provide a direct way for the client to use existing APIs as LLM tools.
+
+## Project Structure
+
+```
+bedrock_llm_tool_calling_example/
+├── bedrock_utcp_client_example.py    # Main application script
+├── providers.json                    # UTCP client configuration
+├── example.env                      # Environment variables template
+├── newsapi_manual.json              # Sample tool manual for NewsAPI
+├── requirements.txt                 # Python dependencies
+└── README.md                       # This file
+```
+
+## Setup Instructions
+
+### 1. Create and Activate Virtual Environment
+
+```bash
+python -m venv venv
+source venv/bin/activate  # On Windows: venv\Scripts\activate
+```
+
+### 2. Install Dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+### 3. Configure Environment
+
+Copy the example environment file and configure your credentials:
+
+```bash
+cp example.env .env
+```
+
+Edit `.env` with your actual credentials:
+- AWS credentials for Bedrock access
+- API keys for any external tools (e.g., NewsAPI)
+
+### 4. Run the Example
+
+```bash
+python bedrock_utcp_client_example.py
+```
+
+The script will start an interactive session where you can ask questions that might require tool usage.
+
+## About UTCP
+
+This example uses the [Universal Tool Calling Protocol (UTCP)](https://github.com/universal-tool-calling-protocol/python-utcp), a secure and scalable standard for defining and interacting with tools across various communication protocols.
+
+Key UTCP features demonstrated:
+- **Multiple Protocols**: HTTP and text file protocol support
+- **Tool Discovery**: Automatic tool search and matching
+- **Extensibility**: Easy integration with existing services and infrastructure
+
+## Configuration
+
+The `providers.json` file defines the UTCP client configuration, including:
+- Tool repositories and search strategies
+- Manual call templates for different protocols
+- Variable substitution and authentication settings
+
+## Dependencies
+
+- **utcp**: Core UTCP library for tool protocol handling
+- **utcp-http**: HTTP protocol plugin for REST API tools
+- **utcp-text**: Text file protocol plugin for local tool manuals
+- **boto3**: AWS SDK for Bedrock integration
+- **python-dotenv**: Environment variable management
+
+## Learn More
+
+- [UTCP Python Library](https://github.com/universal-tool-calling-protocol/python-utcp)
+- [UTCP Examples Repository](https://github.com/universal-tool-calling-protocol/utcp-examples)
+- [Amazon Bedrock Documentation](https://docs.aws.amazon.com/bedrock/)

--- a/python/bedrock_llm_tool_calling_example/bedrock_utcp_client_example.py
+++ b/python/bedrock_llm_tool_calling_example/bedrock_utcp_client_example.py
@@ -56,7 +56,8 @@ def format_tools_for_bedrock(tools: List[Tool]) -> Tuple[List[Dict[str, Any]], D
     tool_name_mapping = {}
     
     for tool in tools:
-        schema = tool.model_dump()
+        # Use exclude_none=True to remove UTCP's null fields that break Bedrock validation
+        schema = tool.model_dump(exclude_none=True)
         
         # Create the input schema JSON
         input_schema_json = {

--- a/python/bedrock_llm_tool_calling_example/newsapi_manual.json
+++ b/python/bedrock_llm_tool_calling_example/newsapi_manual.json
@@ -1,5 +1,6 @@
 {
-  "version": "1.0",
+  "manual_version": "1.0",
+  "utcp_version": "1.0.3",
   "tools": [
     {
       "name": "everything_get",
@@ -124,8 +125,8 @@
           }
         }
       },
-      "tool_provider": {
-        "provider_type": "http",
+      "tool_call_template": {
+        "call_template_type": "http",
         "url": "https://newsapi.org/v2/everything",
         "http_method": "GET",
         "content_type": "application/json",
@@ -169,7 +170,8 @@
             "type": "integer",
             "description": "Use this to page through the results if the total results found is greater than the page size."
           }
-        }
+        },
+        "required": []
       },
       "outputs": {
         "type": "object",
@@ -236,8 +238,8 @@
           }
         }
       },
-      "tool_provider": {
-        "provider_type": "http",
+      "tool_call_template": {
+        "call_template_type": "http",
         "url": "https://newsapi.org/v2/top-headlines",
         "http_method": "GET",
         "content_type": "application/json",

--- a/python/bedrock_llm_tool_calling_example/requirements.txt
+++ b/python/bedrock_llm_tool_calling_example/requirements.txt
@@ -5,3 +5,6 @@ pydantic
 authlib
 python-dotenv
 boto3>=1.28.0
+utcp
+utcp-http
+utcp-text


### PR DESCRIPTION
sorry forgot to add these changes, plus added README for clarity
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes UTCP tool calling schema and clarifies the example is client-only. Adds a README, renames the main script, and adds UTCP dependencies.

- **Bug Fixes**
  - Update newsapi_manual.json: replace tool_provider/provider_type with tool_call_template/call_template_type; remove obsolete version field.
  - Aligns with UTCP call template spec so HTTP calls execute correctly.

- **Dependencies**
  - Add utcp, utcp-http, and utcp-text to requirements.txt.

<!-- End of auto-generated description by cubic. -->

