### PR TITLE
Add Xquik OpenAPI UTCP example

### DIFF
--- a/python/xquik_openapi_example/README.md
+++ b/python/xquik_openapi_example/README.md
@@ -1,0 +1,31 @@
+# Xquik OpenAPI UTCP example
+
+This example shows how to register Xquik's public OpenAPI document as a UTCP HTTP provider. It lets a UTCP client discover Xquik tools for X data workflows such as tweet search, user lookup, follower export, monitoring, webhooks, and write actions.
+
+The script only lists matching tools by default. Set a real `XQUIK_API_KEY` before calling any Xquik endpoint.
+
+## Setup
+
+```sh
+pip install -r requirements.txt
+```
+
+Edit `example.env` and replace the placeholder value:
+
+```sh
+XQUIK_API_KEY=xq_replace_with_your_key
+```
+
+## Run
+
+```sh
+python xquik_openapi_example.py
+```
+
+The example loads `providers.json`, fetches <https://xquik.com/openapi.json>, registers the discovered tools, and prints the first matching tools.
+
+## Notes
+
+- Keep API keys in local environment files or a secret store.
+- Do not commit real API keys.
+- Xquik MCP setup is documented at <https://docs.xquik.com/mcp/overview>.

--- a/python/xquik_openapi_example/example.env
+++ b/python/xquik_openapi_example/example.env
@@ -1,0 +1,1 @@
+XQUIK_API_KEY=xq_replace_with_your_key

--- a/python/xquik_openapi_example/providers.json
+++ b/python/xquik_openapi_example/providers.json
@@ -1,0 +1,31 @@
+{
+  "load_variables_from": [
+    {
+      "variable_loader_type": "dotenv",
+      "env_file_path": "example.env"
+    }
+  ],
+  "tool_repository": {
+    "tool_repository_type": "in_memory"
+  },
+  "tool_search_strategy": {
+    "tool_search_strategy_type": "tag_and_description_word_match",
+    "description_weight": 1,
+    "tag_weight": 3
+  },
+  "manual_call_templates": [
+    {
+      "name": "xquik",
+      "call_template_type": "http",
+      "http_method": "GET",
+      "url": "https://xquik.com/openapi.json",
+      "content_type": "application/json",
+      "auth": {
+        "auth_type": "api_key",
+        "api_key": "$XQUIK_API_KEY",
+        "var_name": "x-api-key",
+        "location": "header"
+      }
+    }
+  ]
+}

--- a/python/xquik_openapi_example/providers.json
+++ b/python/xquik_openapi_example/providers.json
@@ -20,7 +20,7 @@
       "http_method": "GET",
       "url": "https://xquik.com/openapi.json",
       "content_type": "application/json",
-      "auth": {
+      "auth_tools": {
         "auth_type": "api_key",
         "api_key": "$XQUIK_API_KEY",
         "var_name": "x-api-key",

--- a/python/xquik_openapi_example/requirements.txt
+++ b/python/xquik_openapi_example/requirements.txt
@@ -1,0 +1,3 @@
+python-dotenv
+utcp
+utcp-http

--- a/python/xquik_openapi_example/xquik_openapi_example.py
+++ b/python/xquik_openapi_example/xquik_openapi_example.py
@@ -1,0 +1,31 @@
+import asyncio
+import json
+from pathlib import Path
+
+from utcp.data.utcp_client_config import UtcpClientConfigSerializer
+from utcp.utcp_client import UtcpClient
+
+
+async def main():
+    base_dir = Path(__file__).parent
+    config_path = base_dir / "providers.json"
+    config_data = json.loads(config_path.read_text(encoding="utf-8"))
+
+    for variable_loader in config_data.get("load_variables_from", []):
+        if variable_loader.get("variable_loader_type") == "dotenv":
+            variable_loader["env_file_path"] = str(base_dir / "example.env")
+
+    config = UtcpClientConfigSerializer().validate_dict(config_data)
+    client = await UtcpClient.create(root_dir=str(base_dir), config=config)
+
+    tools = await client.search_tools("tweet search user lookup follower export", limit=12)
+    print("Matching Xquik tools:")
+    for tool in tools:
+        description = getattr(tool, "description", "")
+        print(f" - {tool.name}: {description}")
+
+    print("\nSet XQUIK_API_KEY in example.env before calling a Xquik tool.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Summary
- Add a Python UTCP example that registers Xquik from its public OpenAPI document.
- Include a placeholder environment file and local setup notes.
- Keep the script discovery-only by default so it does not call Xquik endpoints without a real key.

Validation
- python3 -m json.tool python/xquik_openapi_example/providers.json
- python3 -m py_compile python/xquik_openapi_example/xquik_openapi_example.py
- git diff --check
- Verified Xquik OpenAPI and MCP documentation links with curl.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Python UTCP example that registers Xquik tools from its public OpenAPI and prints matching tools. It runs in discovery-only mode by default; real calls require `XQUIK_API_KEY`.

- **New Features**
  - New `python/xquik_openapi_example` with `xquik_openapi_example.py` that loads `providers.json`, fetches `https://xquik.com/openapi.json`, registers tools, and prints matches.
  - Uses a dotenv loader; `XQUIK_API_KEY` is applied to generated Xquik tools via the `x-api-key` header. `example.env` and README included for quick setup.

- **Dependencies**
  - Adds `python-dotenv`, `utcp`, and `utcp-http` in `requirements.txt`.

<sup>Written for commit d5d18a038770907c8aa7670ee1033e4f72607526. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/universal-tool-calling-protocol/utcp-examples/pull/14?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

